### PR TITLE
feat: allow database to be bootstrapped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-bootstrap"
+version = "0.1.0"
+source = "git+https://github.com/alexander-jackson/sqlx-bootstrap.git#3c37b2990e933173748be0950bc261dd89113d5a"
+dependencies = [
+ "sqlx",
+ "tracing",
+]
+
+[[package]]
 name = "sqlx-core"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2089,7 @@ dependencies = [
  "http-body-util",
  "serde",
  "sqlx",
+ "sqlx-bootstrap",
  "tera",
  "tokio",
  "tower 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ color-eyre = "0.6.3"
 dotenvy = "0.15.7"
 serde = { version = "1.0.208", features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono"] }
+sqlx-bootstrap = { git = "https://github.com/alexander-jackson/sqlx-bootstrap.git", version = "0.1.0" }
 tera = "1.20.0"
 tokio = { version = "1.39.3", features = ["rt-multi-thread", "macros"] }
 tower = { version = "0.5.0", features = ["tracing"] }


### PR DESCRIPTION
Since we're running on a shared host, let's bootstrap the database so we can just start and create whatever we need.

This change:
* Adds a dependency on `sqlx-bootstrap`
* Adds environment variables to bootstrap everything
