### PR TITLE
feat: expose on unspecified port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
     let template_engine = TemplateEngine::new()?;
 
     let router = build_router(template_engine, pool);
-    let listener = TcpListener::bind("localhost:8000").await?;
+    let listener = TcpListener::bind("0.0.0.0:8000").await?;
 
     axum::serve(listener, router).await?;
 


### PR DESCRIPTION
This is failing to handle requests as it's listening on `localhost` instead of the unspecified host.

This change:
* Updates the binding
