### PR TITLE
fix: resolve failing startups

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,3 +22,6 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/today:${{ steps.tag.outputs.value }}
+      - name: Inform `tag-updater`
+        run: |
+          curl https://tags.opentracker.app/update -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.TAG_UPDATER_PASSPHRASE }}" --data '{"service": "today", "tag": "${{ steps.tag.outputs.value }}"}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,6 @@ RUN cargo build --release --target x86_64-unknown-linux-musl --bin today
 
 FROM gcr.io/distroless/static
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/today .
+COPY ./templates ./templates
+COPY ./assets ./assets
 ENTRYPOINT ["./today"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::net::{Ipv4Addr, SocketAddrV4};
+
 use axum::body::Body;
 use axum::extract::{Path, State};
 use axum::http::header::LOCATION;
@@ -92,7 +94,11 @@ async fn main() -> Result<()> {
     let template_engine = TemplateEngine::new()?;
 
     let router = build_router(template_engine, pool);
-    let listener = TcpListener::bind("0.0.0.0:8000").await?;
+
+    let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8000);
+    let listener = TcpListener::bind(addr).await?;
+
+    tracing::info!(?addr, "listening for incoming requests");
 
     axum::serve(listener, router).await?;
 


### PR DESCRIPTION
`today` is seemingly using 100% of the CPU on the instance for no good reason, perhaps trying to find templates?

This change:
* Adds `tag-updater` so we get automated updates
* Copies the templates and assets in
* Updates the binding address
