### PR TITLE
refactor: improve persistence API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ async fn templated(
         ..
     }): State<ApplicationState>,
 ) -> ServerResult<RenderedTemplate> {
-    let now = Utc::now().naive_local();
+    let now = Utc::now().date_naive();
     let items = crate::persistence::select_items(&pool, now).await?;
 
     let mut context = Context::new();

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,13 +1,11 @@
-use chrono::{NaiveDateTime, Utc};
+use chrono::{NaiveDate, NaiveDateTime, Utc};
 use color_eyre::eyre::Result;
 use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::Item;
 
-pub async fn select_items(pool: &PgPool, now: NaiveDateTime) -> Result<Vec<Item>> {
-    let today = now.date();
-
+pub async fn select_items(pool: &PgPool, date: NaiveDate) -> Result<Vec<Item>> {
     let items = sqlx::query_as!(
         Item,
         r#"
@@ -21,7 +19,7 @@ pub async fn select_items(pool: &PgPool, now: NaiveDateTime) -> Result<Vec<Item>
             WHERE i.created_at::date = $1
             ORDER BY i.id, i.created_at, ie.occurred_at DESC
         "#,
-        today,
+        date,
     )
     .fetch_all(pool)
     .await?;

--- a/src/persistence/tests.rs
+++ b/src/persistence/tests.rs
@@ -17,6 +17,7 @@ async fn create_item(pool: &PgPool, content: &str, created_at: NaiveDateTime) ->
 fn items_are_only_returned_for_the_current_day(pool: PgPool) -> Result<()> {
     let now = Utc::now().naive_local();
     let yesterday = now - Duration::days(1);
+    let today = now.date();
 
     // Insert an item for the current day
     let item_uid1 = create_item(&pool, "Today", now).await?;
@@ -25,7 +26,7 @@ fn items_are_only_returned_for_the_current_day(pool: PgPool) -> Result<()> {
     let item_uid2 = create_item(&pool, "Yesterday", yesterday).await?;
 
     // Fetch all the items for today
-    let items: HashSet<Uuid> = super::select_items(&pool, now)
+    let items: HashSet<Uuid> = super::select_items(&pool, today)
         .await?
         .iter()
         .map(|item| item.item_uid)
@@ -40,26 +41,27 @@ fn items_are_only_returned_for_the_current_day(pool: PgPool) -> Result<()> {
 #[sqlx::test]
 fn item_states_can_be_modified(pool: PgPool) -> Result<()> {
     let now = Utc::now().naive_local();
+    let today = now.date();
 
     // Insert an item to modify
     let item_uid = create_item(&pool, "Content", now).await?;
 
     // Check it's currently unchecked
-    let items = super::select_items(&pool, now).await?;
+    let items = super::select_items(&pool, today).await?;
     assert_eq!(items[0].state, false);
 
     // Modify the item
     super::update_item(&pool, item_uid, true).await?;
 
     // Check the new state is reflected
-    let items = super::select_items(&pool, now).await?;
+    let items = super::select_items(&pool, today).await?;
     assert_eq!(items[0].state, true);
 
     // Update it back to be unchecked
     super::update_item(&pool, item_uid, false).await?;
 
     // Check it's back to what it was before
-    let items = super::select_items(&pool, now).await?;
+    let items = super::select_items(&pool, today).await?;
     assert_eq!(items[0].state, false);
 
     Ok(())


### PR DESCRIPTION
The `select_items` function takes a `NaiveDateTime` to select items for, but really it works by getting anything for that day. This should be more obvious and results in nicer variable names.

This change:
* Updates the API slightly and deals with the change
