### PR TITLE
feat: hide ticked items

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -11,6 +11,19 @@ const onDocumentLoad = () => {
         headers: {
           "Content-Type": "application/json",
         },
+      }).then(() => {
+        const checkedItems = document.getElementById("checked-items");
+        const uncheckedItems = document.getElementById("unchecked-items");
+
+        const listElement = checkbox.parentNode;
+
+        if (state) {
+          uncheckedItems.removeChild(listElement);
+          checkedItems.appendChild(listElement);
+        } else {
+          checkedItems.removeChild(listElement);
+          uncheckedItems.appendChild(listElement);
+        }
       });
     };
   }

--- a/assets/style.css
+++ b/assets/style.css
@@ -7,6 +7,10 @@ body {
   margin: 0 auto;
 }
 
+.container {
+  padding: 0px 40px;
+}
+
 h1 {
   text-align: center;
   font-size: 75px;
@@ -14,6 +18,8 @@ h1 {
 
 ul {
   list-style-type: none;
+  padding: 0px;
+  margin: 10px;
 }
 
 li {
@@ -31,5 +37,9 @@ input[type="checkbox"] {
   height: 30px;
   font-size: 25px;
   display: block;
-  margin: 0 auto;
+  margin: 20px auto;
+}
+
+details {
+  font-size: 30px;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,8 +116,22 @@ async fn templated(
     let now = Utc::now().date_naive();
     let items = crate::persistence::select_items(&pool, now).await?;
 
+    let mut checked_items = Vec::new();
+    let mut unchecked_items = Vec::new();
+
+    for item in items {
+        let target = if item.state {
+            &mut checked_items
+        } else {
+            &mut unchecked_items
+        };
+
+        target.push(item);
+    }
+
     let mut context = Context::new();
-    context.insert("items", &items);
+    context.insert("checked_items", &checked_items);
+    context.insert("unchecked_items", &unchecked_items);
 
     let rendered = template_engine.render("index.tera.html", &context)?;
 

--- a/templates/index.tera.html
+++ b/templates/index.tera.html
@@ -9,21 +9,10 @@
   <body class="container">
     <h1>Today</h1>
 
-    <ul>
-      {% for item in items %}
+    <ul id="unchecked-items">
+      {% for item in unchecked_items %}
       <li>
-        <input
-          type="checkbox"
-          id="{{ item.item_uid }}"
-          {%
-          if
-          item.state
-          %}
-          checked
-          {%
-          endif
-          %}
-        />
+        <input type="checkbox" id="{{ item.item_uid }}" />
         {{ item.content }}
       </li>
       {% endfor %}
@@ -32,5 +21,18 @@
     <form action="/add" method="post">
       <input type="text" id="add-item" name="content" />
     </form>
+
+    <details>
+      <summary>Archived Items</summary>
+
+      <ul id="checked-items">
+        {% for item in checked_items %}
+        <li>
+          <input type="checkbox" id="{{ item.item_uid }}" checked />
+          {{ item.content }}
+        </li>
+        {% endfor %}
+      </ul>
+    </details>
   </body>
 </html>


### PR DESCRIPTION
Ticked items cause a lot of clutter, especially towards the end of the day. It would be good to hide them by default, allowing the user to bring them back if needed but having them collapsed into a separate view.

This change:
* Updates the JavaScript to move the elements around
* Updates the template to add some extra sections
* Updates the server to partition the items
* Tweaks the CSS so everything looks vaguely nice
