### PR TITLE
refactor: break up `main`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,86 +1,15 @@
 use std::net::{Ipv4Addr, SocketAddrV4};
 
-use axum::body::Body;
-use axum::extract::{Path, State};
-use axum::http::header::LOCATION;
-use axum::http::StatusCode;
-use axum::response::Response;
-use axum::routing::{get, patch, post};
-use axum::{Form, Json, Router};
-use chrono::Utc;
-use color_eyre::eyre::{eyre, Result};
-use serde::{Deserialize, Serialize};
-use sqlx::PgPool;
-use sqlx_bootstrap::{ApplicationConfig, BootstrapConfig, ConnectionConfig, RootConfig};
-use tera::Context;
+use color_eyre::eyre::Result;
 use tokio::net::TcpListener;
-use tower_http::services::ServeDir;
-use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
-use uuid::Uuid;
 
 mod error;
 mod persistence;
+mod router;
 mod templates;
 
-use crate::error::ServerResult;
-use crate::templates::{RenderedTemplate, TemplateEngine};
-
-#[derive(Serialize)]
-struct Item {
-    item_uid: Uuid,
-    content: String,
-    state: bool,
-}
-
-#[derive(Clone)]
-struct ApplicationState {
-    template_engine: TemplateEngine,
-    pool: PgPool,
-}
-
-fn build_router(template_engine: TemplateEngine, pool: PgPool) -> Router {
-    let state = ApplicationState {
-        template_engine,
-        pool,
-    };
-
-    Router::new()
-        .route("/", get(templated))
-        .route("/add", post(add_item))
-        .route("/update/:item_uid", patch(update_item))
-        .layer(TraceLayer::new_for_http())
-        .nest_service("/assets", ServeDir::new("assets"))
-        .with_state(state)
-}
-
-fn get_env_var(key: &str) -> Result<String> {
-    std::env::var(key).map_err(|_| eyre!("Failed to get environment variable '{key}'"))
-}
-
-async fn bootstrap_database() -> Result<PgPool> {
-    let root_username = get_env_var("ROOT_USERNAME")?;
-    let root_password = get_env_var("ROOT_PASSWORD")?;
-    let root_database = get_env_var("ROOT_DATABASE")?;
-
-    let app_username = get_env_var("APP_USERNAME")?;
-    let app_password = get_env_var("APP_PASSWORD")?;
-    let app_database = get_env_var("APP_DATABASE")?;
-
-    let host = get_env_var("DATABASE_HOST")?;
-    let port = get_env_var("DATABASE_PORT")?.parse()?;
-
-    let root_config = RootConfig::new(&root_username, &root_password, &root_database);
-    let app_config = ApplicationConfig::new(&app_username, &app_password, &app_database);
-    let conn_config = ConnectionConfig::new(&host, port);
-
-    let config = BootstrapConfig::new(root_config, app_config, conn_config);
-    let pool = config.bootstrap().await?;
-
-    sqlx::migrate!().run(&pool).await?;
-
-    Ok(pool)
-}
+use crate::templates::TemplateEngine;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -91,10 +20,10 @@ async fn main() -> Result<()> {
 
     dotenvy::dotenv().ok();
 
-    let pool = bootstrap_database().await?;
+    let pool = crate::persistence::bootstrap::run().await?;
     let template_engine = TemplateEngine::new()?;
 
-    let router = build_router(template_engine, pool);
+    let router = crate::router::build(template_engine, pool);
 
     let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8000);
     let listener = TcpListener::bind(addr).await?;
@@ -104,89 +33,6 @@ async fn main() -> Result<()> {
     axum::serve(listener, router).await?;
 
     Ok(())
-}
-
-async fn templated(
-    State(ApplicationState {
-        template_engine,
-        pool,
-        ..
-    }): State<ApplicationState>,
-) -> ServerResult<RenderedTemplate> {
-    let now = Utc::now().date_naive();
-    let items = crate::persistence::select_items(&pool, now).await?;
-
-    let mut checked_items = Vec::new();
-    let mut unchecked_items = Vec::new();
-
-    for item in items {
-        let target = if item.state {
-            &mut checked_items
-        } else {
-            &mut unchecked_items
-        };
-
-        target.push(item);
-    }
-
-    let mut context = Context::new();
-    context.insert("checked_items", &checked_items);
-    context.insert("unchecked_items", &unchecked_items);
-
-    let rendered = template_engine.render("index.tera.html", &context)?;
-
-    Ok(rendered)
-}
-
-#[derive(Debug, Deserialize)]
-struct AddItemForm {
-    content: String,
-}
-
-async fn add_item(
-    State(ApplicationState { pool, .. }): State<ApplicationState>,
-    Form(AddItemForm { content }): Form<AddItemForm>,
-) -> ServerResult<Response> {
-    tracing::info!(?content, "Got something from the client");
-
-    let item_uid = Uuid::new_v4();
-    let now = Utc::now().naive_local();
-
-    crate::persistence::create_item(&pool, item_uid, &content, now).await?;
-
-    Ok(redirect("/")?)
-}
-
-#[derive(Debug, Deserialize)]
-struct UpdateItemRequest {
-    state: bool,
-}
-
-async fn update_item(
-    State(ApplicationState { pool, .. }): State<ApplicationState>,
-    Path(item_uid): Path<Uuid>,
-    Json(request): Json<UpdateItemRequest>,
-) -> ServerResult<Response> {
-    crate::persistence::update_item(&pool, item_uid, request.state).await?;
-
-    Ok(success()?)
-}
-
-fn success() -> Result<Response> {
-    let res = Response::builder()
-        .status(StatusCode::OK)
-        .body(Body::empty())?;
-
-    Ok(res)
-}
-
-fn redirect(path: &'static str) -> Result<Response> {
-    let res = Response::builder()
-        .status(StatusCode::FOUND)
-        .header(LOCATION, path)
-        .body(Body::empty())?;
-
-    Ok(res)
 }
 
 #[cfg(test)]

--- a/src/persistence/bootstrap.rs
+++ b/src/persistence/bootstrap.rs
@@ -1,0 +1,31 @@
+use color_eyre::eyre::{eyre, Result};
+use sqlx::PgPool;
+use sqlx_bootstrap::{ApplicationConfig, BootstrapConfig, ConnectionConfig, RootConfig};
+
+fn get_env_var(key: &str) -> Result<String> {
+    std::env::var(key).map_err(|_| eyre!("Failed to get environment variable '{key}'"))
+}
+
+pub async fn run() -> Result<PgPool> {
+    let root_username = get_env_var("ROOT_USERNAME")?;
+    let root_password = get_env_var("ROOT_PASSWORD")?;
+    let root_database = get_env_var("ROOT_DATABASE")?;
+
+    let app_username = get_env_var("APP_USERNAME")?;
+    let app_password = get_env_var("APP_PASSWORD")?;
+    let app_database = get_env_var("APP_DATABASE")?;
+
+    let host = get_env_var("DATABASE_HOST")?;
+    let port = get_env_var("DATABASE_PORT")?.parse()?;
+
+    let root_config = RootConfig::new(&root_username, &root_password, &root_database);
+    let app_config = ApplicationConfig::new(&app_username, &app_password, &app_database);
+    let conn_config = ConnectionConfig::new(&host, port);
+
+    let config = BootstrapConfig::new(root_config, app_config, conn_config);
+    let pool = config.bootstrap().await?;
+
+    sqlx::migrate!().run(&pool).await?;
+
+    Ok(pool)
+}

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,9 +1,17 @@
 use chrono::{NaiveDate, NaiveDateTime, Utc};
 use color_eyre::eyre::Result;
+use serde::Serialize;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::Item;
+pub mod bootstrap;
+
+#[derive(Serialize)]
+pub struct Item {
+    item_uid: Uuid,
+    content: String,
+    pub state: bool,
+}
 
 pub async fn select_items(pool: &PgPool, date: NaiveDate) -> Result<Vec<Item>> {
     let items = sqlx::query_as!(

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,122 @@
+use axum::body::Body;
+use axum::extract::{Form, Json, Path, State};
+use axum::http::header::LOCATION;
+use axum::http::StatusCode;
+use axum::response::Response;
+use axum::routing::{get, patch, post};
+use axum::Router;
+use chrono::Utc;
+use color_eyre::eyre::Result;
+use serde::Deserialize;
+use sqlx::PgPool;
+use tera::Context;
+use tower_http::services::ServeDir;
+use tower_http::trace::TraceLayer;
+use uuid::Uuid;
+
+use crate::error::ServerResult;
+use crate::templates::{RenderedTemplate, TemplateEngine};
+
+#[derive(Clone)]
+struct ApplicationState {
+    template_engine: TemplateEngine,
+    pool: PgPool,
+}
+
+pub fn build(template_engine: TemplateEngine, pool: PgPool) -> Router {
+    let state = ApplicationState {
+        template_engine,
+        pool,
+    };
+
+    Router::new()
+        .route("/", get(templated))
+        .route("/add", post(add_item))
+        .route("/update/:item_uid", patch(update_item))
+        .layer(TraceLayer::new_for_http())
+        .nest_service("/assets", ServeDir::new("assets"))
+        .with_state(state)
+}
+
+async fn templated(
+    State(ApplicationState {
+        template_engine,
+        pool,
+        ..
+    }): State<ApplicationState>,
+) -> ServerResult<RenderedTemplate> {
+    let now = Utc::now().date_naive();
+    let items = crate::persistence::select_items(&pool, now).await?;
+
+    let mut checked_items = Vec::new();
+    let mut unchecked_items = Vec::new();
+
+    for item in items {
+        let target = if item.state {
+            &mut checked_items
+        } else {
+            &mut unchecked_items
+        };
+
+        target.push(item);
+    }
+
+    let mut context = Context::new();
+    context.insert("checked_items", &checked_items);
+    context.insert("unchecked_items", &unchecked_items);
+
+    let rendered = template_engine.render("index.tera.html", &context)?;
+
+    Ok(rendered)
+}
+
+#[derive(Debug, Deserialize)]
+struct AddItemForm {
+    content: String,
+}
+
+async fn add_item(
+    State(ApplicationState { pool, .. }): State<ApplicationState>,
+    Form(AddItemForm { content }): Form<AddItemForm>,
+) -> ServerResult<Response> {
+    tracing::info!(?content, "Got something from the client");
+
+    let item_uid = Uuid::new_v4();
+    let now = Utc::now().naive_local();
+
+    crate::persistence::create_item(&pool, item_uid, &content, now).await?;
+
+    Ok(redirect("/")?)
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateItemRequest {
+    state: bool,
+}
+
+async fn update_item(
+    State(ApplicationState { pool, .. }): State<ApplicationState>,
+    Path(item_uid): Path<Uuid>,
+    Json(request): Json<UpdateItemRequest>,
+) -> ServerResult<Response> {
+    crate::persistence::update_item(&pool, item_uid, request.state).await?;
+
+    Ok(success()?)
+}
+
+fn success() -> Result<Response> {
+    let res = Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::empty())?;
+
+    Ok(res)
+}
+
+fn redirect(path: &'static str) -> Result<Response> {
+    let res = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(LOCATION, path)
+        .body(Body::empty())?;
+
+    Ok(res)
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn build_router(pool: PgPool) -> Result<Router> {
     let template_engine = TemplateEngine::new()?;
-    let router = crate::build_router(template_engine, pool);
+    let router = crate::router::build(template_engine, pool);
 
     Ok(router)
 }


### PR DESCRIPTION
The `main.rs` file is too busy, so let's split some of it out and allow each of the files to be dedicated to a specific piece of work more.

This change:
* Moves the bootstrap code to `src/persistence/bootstrap.rs`
* Moves the endpoints and router creation to `src/router.rs`
* Updates all the references and imports
