### PR TITLE
feat: add `title` tag

### DIFF
--- a/templates/index.tera.html
+++ b/templates/index.tera.html
@@ -4,6 +4,7 @@
     <link rel="stylesheet" href="assets/style.css" />
     <script type="text/javascript" src="assets/script.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Today</title>
   </head>
 
   <body class="container">


### PR DESCRIPTION
Currently the tab just appears as the browser URL which isn't very nice and also leaks the public URL.

This change:
* Adds a `title` tag to tidy it up a little
