### PR TITLE
feat: begin adding accounts

### DIFF
--- a/.sqlx/query-8f535edbc11a1126ee093e5fe246678b9eec01caa5b16f08750c75a8fee9bd36.json
+++ b/.sqlx/query-8f535edbc11a1126ee093e5fe246678b9eec01caa5b16f08750c75a8fee9bd36.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO account (account_uid, email_address, password, created_at)\n            VALUES ($1, $2, $3, now()::timestamp)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8f535edbc11a1126ee093e5fe246678b9eec01caa5b16f08750c75a8fee9bd36"
+}

--- a/.sqlx/query-a8d829258fb62b8e519704e79b6836148cff5a91323df71fd45a0f1697918561.json
+++ b/.sqlx/query-a8d829258fb62b8e519704e79b6836148cff5a91323df71fd45a0f1697918561.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                account_uid,\n                email_address,\n                password\n            FROM account\n            WHERE email_address = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "email_address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "password",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a8d829258fb62b8e519704e79b6836148cff5a91323df71fd45a0f1697918561"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bcrypt"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65938ed058ef47d92cf8b346cc76ef48984572ade631927e9937b5ffc7662c7"
+dependencies = [
+ "base64 0.22.1",
+ "blowfish",
+ "getrandom",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -272,6 +295,16 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -859,6 +892,15 @@ checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2083,6 +2125,7 @@ name = "today"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "bcrypt",
  "chrono",
  "color-eyre",
  "dotenvy",
@@ -2564,7 +2607,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
+bcrypt = "0.15.1"
 http-body-util = "0.1.2"
 tower-util = "0.3.1"

--- a/migrations/20240826082447_AddAccountsConcept.sql
+++ b/migrations/20240826082447_AddAccountsConcept.sql
@@ -1,0 +1,12 @@
+CREATE TABLE account (
+  id BIGINT GENERATED ALWAYS AS IDENTITY,
+  account_uid UUID NOT NULL,
+  email_address TEXT NOT NULL,
+  password TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+
+  CONSTRAINT pk_account PRIMARY KEY (id),
+  CONSTRAINT uk_account_account_uid UNIQUE (account_uid)
+);
+
+CREATE UNIQUE INDEX uk_account_email_address_lower ON account (lower(email_address));

--- a/src/persistence/account.rs
+++ b/src/persistence/account.rs
@@ -1,0 +1,121 @@
+#![allow(dead_code)]
+
+use color_eyre::eyre::Result;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+pub struct EmailAddress(String);
+
+impl<T> From<T> for EmailAddress
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        Self(value.as_ref().to_lowercase())
+    }
+}
+
+pub struct Account {
+    account_uid: Uuid,
+    email_address: String,
+    password: String,
+}
+
+async fn create_account(
+    pool: &PgPool,
+    account_uid: Uuid,
+    email_address: &EmailAddress,
+    password: &str,
+) -> Result<()> {
+    sqlx::query!(
+        r#"
+            INSERT INTO account (account_uid, email_address, password, created_at)
+            VALUES ($1, $2, $3, now()::timestamp)
+        "#,
+        account_uid,
+        email_address.0,
+        password
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn fetch_account_by_email(
+    pool: &PgPool,
+    email_address: EmailAddress,
+) -> Result<Option<Account>> {
+    let account = sqlx::query_as!(
+        Account,
+        r#"
+            SELECT
+                account_uid,
+                email_address,
+                password
+            FROM account
+            WHERE email_address = $1
+        "#,
+        email_address.0
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(account)
+}
+
+#[cfg(test)]
+mod tests {
+    use bcrypt::DEFAULT_COST;
+    use color_eyre::eyre::Result;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    use super::{create_account, fetch_account_by_email, EmailAddress};
+
+    #[sqlx::test]
+    async fn non_existent_email_addresses_return_no_results(pool: PgPool) -> Result<()> {
+        let account = fetch_account_by_email(&pool, "example@domain.com".into()).await?;
+
+        assert!(account.is_none());
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn accounts_can_be_created(pool: PgPool) -> Result<()> {
+        let account_uid = Uuid::new_v4();
+        let email_address = EmailAddress::from("john@gmail.com");
+        let password = bcrypt::hash("password", DEFAULT_COST)?;
+
+        // Insert the account
+        create_account(&pool, account_uid, &email_address, &password).await?;
+
+        // Validate we can fetch it by email again
+        let account = fetch_account_by_email(&pool, email_address).await?;
+
+        assert_eq!(account.map(|a| a.account_uid), Some(account_uid));
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn cannot_create_multiple_accounts_with_same_email(pool: PgPool) -> Result<()> {
+        let email_address = EmailAddress::from("john@gmail.com");
+        let password = bcrypt::hash("password", DEFAULT_COST)?;
+
+        // Insert the account
+        create_account(&pool, Uuid::new_v4(), &email_address, &password).await?;
+
+        // Create another one with the same email
+        let res = create_account(&pool, Uuid::new_v4(), &email_address, &password).await;
+
+        let expected_error_message =
+            r#"duplicate key value violates unique constraint "uk_account_email_address_lower""#;
+
+        assert!(res.is_err_and(|e| e.to_string().contains(expected_error_message)));
+
+        Ok(())
+    }
+}

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
 
+pub mod account;
 pub mod bootstrap;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
While having a publicly accessible website is great and all, it means anyone can view my items and modify them. It's also not very extensible if others feel like giving it a try.

Let's start working in the concept of accounts, so that we can create them manually in the database and then associate all the existing items with the first one.

This change:
* Adds a basic table structure
* Adds some persistence and tests around it
