### PR TITLE
refactor: add `utils` module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,10 @@ mod error;
 mod persistence;
 mod router;
 mod templates;
+mod utils;
 
 use crate::templates::TemplateEngine;
+use crate::utils::get_env_var;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -25,9 +27,9 @@ async fn main() -> Result<()> {
 
     let pool = crate::persistence::bootstrap::run().await?;
     let template_engine = TemplateEngine::new()?;
-    let cookie_key = Key::from(std::env::var("COOKIE_KEY")?.as_bytes());
+    let cookie_key = Key::from(get_env_var("COOKIE_KEY")?.as_bytes());
 
-    let jwt_key = std::env::var("JWT_KEY")?;
+    let jwt_key = get_env_var("JWT_KEY")?;
     let encoding_key = EncodingKey::from_secret(jwt_key.as_bytes());
     let decoding_key = DecodingKey::from_secret(jwt_key.as_bytes());
 

--- a/src/persistence/bootstrap.rs
+++ b/src/persistence/bootstrap.rs
@@ -1,10 +1,8 @@
-use color_eyre::eyre::{eyre, Result};
+use color_eyre::eyre::Result;
 use sqlx::PgPool;
 use sqlx_bootstrap::{ApplicationConfig, BootstrapConfig, ConnectionConfig, RootConfig};
 
-fn get_env_var(key: &str) -> Result<String> {
-    std::env::var(key).map_err(|_| eyre!("Failed to get environment variable '{key}'"))
-}
+use crate::utils::get_env_var;
 
 pub async fn run() -> Result<PgPool> {
     let root_username = get_env_var("ROOT_USERNAME")?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,8 @@
+use color_eyre::eyre::{Context, Result};
+
+pub fn get_env_var(key: &str) -> Result<String> {
+    let value = std::env::var(key)
+        .wrap_err_with(|| format!("failed to find key '{key}' in the environment variables"))?;
+
+    Ok(value)
+}


### PR DESCRIPTION
`get_env_var` is useful in a few different places, so let's move it to a shared location and improve the error handling a little bit.

This change:
* Adds a `utils.rs` module
* Moves the `get_env_var` function there
* Wraps the error instead of throwing it away during mapping
* Uses it in another location
