### PR TITLE
refactor: improve tests

### DIFF
--- a/src/persistence/account.rs
+++ b/src/persistence/account.rs
@@ -21,7 +21,8 @@ pub struct HashedPassword(String);
 
 impl HashedPassword {
     pub fn from_raw<T: AsRef<str>>(value: T) -> Result<Self> {
-        let hashed = bcrypt::hash(value.as_ref(), bcrypt::DEFAULT_COST)?;
+        let cost = if cfg!(test) { 4 } else { bcrypt::DEFAULT_COST };
+        let hashed = bcrypt::hash(value.as_ref(), cost)?;
 
         Ok(Self(hashed))
     }


### PR DESCRIPTION
The tests are still quite messy from hacking the account concept in, so let's get those improved. Additionally, we're spending a while doing `bcrypt` hashing as we're using the default cost so let's reduce that down.

This change:
* Extracts some common functionality in the tests
* Reduces the `bcrypt` cost from 12 to 4 in tests to speed them up
