### PR TITLE
fix: stop Firefox caching checkboxes

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,5 +1,5 @@
 use axum::body::Body;
-use axum::http::header::CONTENT_TYPE;
+use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use color_eyre::eyre::Result;
@@ -33,6 +33,7 @@ impl IntoResponse for RenderedTemplate {
         Response::builder()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, "text/html")
+            .header(CACHE_CONTROL, "no-store")
             .body(Body::from(self.inner))
             .unwrap()
     }


### PR DESCRIPTION
Firefox seems to be exhibiting some weird behaviour both locally and in production. If one adds 2 items, checks the second one (to move it down to the archive) and then refreshes the page, the first item will appear as checked despite not having the relevant state on the HTML side.

According to [this post](https://stackoverflow.com/a/299849) this is due to caching in Firefox, where it doesn't fully re-render the template. Since all of this happens server-side and we should never trust the client here, it's fine to turn off caching for these in the temporary future.

At some point we may want to introduce proper caching here, but we can do that by implementing it on the server-side and invalidating them when the user adds or modifies an item.

This change:
* Adds a `Cache-Control: no-store` to template responses to force Firefox (and potentially other browsers) to re-render fully
