### PR TITLE
refactor: separate index context

### DIFF
--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -35,10 +35,10 @@ impl From<String> for ItemState {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Item {
-    item_uid: Uuid,
-    content: String,
+    pub item_uid: Uuid,
+    pub content: String,
     pub state: ItemState,
 }
 


### PR DESCRIPTION
The context of the index page is currently just a `tera::Context` with arbitrary keys. This is somewhat fragile and probably not the recommended way of doing things, so let's use a proper type here.

This will make it easier to cache in the future as well.

This change:
* Moves the partitioning logic to `IndexContext`
* Updates the code to handle serialization
* Adds some tests to make sure it all works
