### PR TITLE
chore: remove dead code

### DIFF
--- a/src/persistence/account.rs
+++ b/src/persistence/account.rs
@@ -55,21 +55,6 @@ pub async fn create_account(
     Ok(())
 }
 
-pub async fn select_oldest(pool: &PgPool) -> Result<Option<Uuid>> {
-    let account_uid = sqlx::query_scalar!(
-        r#"
-            SELECT account_uid
-            FROM account
-            ORDER BY created_at
-            LIMIT 1
-        "#
-    )
-    .fetch_optional(pool)
-    .await?;
-
-    Ok(account_uid)
-}
-
 pub async fn fetch_account_by_email(
     pool: &PgPool,
     email_address: &EmailAddress,


### PR DESCRIPTION
This function is no longer being used, presumably after the great account migration.

This change:
* Removes it
