### PR TITLE
fix: stop sanitising emails

### DIFF
--- a/src/persistence/tests.rs
+++ b/src/persistence/tests.rs
@@ -5,7 +5,7 @@ use color_eyre::eyre::Result;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::persistence::account::{EmailAddress, HashedPassword};
+use crate::persistence::account::HashedPassword;
 use crate::persistence::ItemState;
 
 const SOME_EMAIL_ADDRESS: &str = "test@test.com";
@@ -30,7 +30,7 @@ async fn create_account(pool: &PgPool, email_address: &str) -> Result<Uuid> {
     super::account::create_account(
         &pool,
         account_uid,
-        &EmailAddress::from(email_address),
+        email_address,
         &HashedPassword::from_raw("foobar")?,
     )
     .await?;

--- a/src/router.rs
+++ b/src/router.rs
@@ -121,7 +121,6 @@ async fn register(
     }): Form<Registration>,
 ) -> ServerResult<Response> {
     let account_uid = Uuid::new_v4();
-    let email_address = EmailAddress::from(email_address);
     let hashed_password = HashedPassword::from_raw(&raw_password)?;
 
     crate::persistence::account::create_account(


### PR DESCRIPTION
Inbound emails are sanitised to be entirely lowercase, but realistically we should just store whatever is provided to us. Searching can use the lowercase version for index performance.

This change:
* Updates insertion to use a raw `&str`
* Updates all the rest of the code

Fixes #16.
