### PR TITLE
fix: render login template correctly

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -139,7 +139,7 @@ async fn login(
         template_engine, ..
     }): State<ApplicationState>,
 ) -> ServerResult<RenderedTemplate> {
-    let rendered = template_engine.render_serialized("login.tera.html", &())?;
+    let rendered = template_engine.render_contextless("login.tera.html")?;
 
     Ok(rendered)
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -56,6 +56,13 @@ impl TemplateEngine {
 
         Ok(RenderedTemplate { inner: rendered })
     }
+
+    pub fn render_contextless(&self, template: &str) -> Result<RenderedTemplate> {
+        let context = Context::default();
+        let rendered = self.inner.render(template, &context)?;
+
+        Ok(RenderedTemplate { inner: rendered })
+    }
 }
 
 pub struct RenderedTemplate {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -243,3 +243,23 @@ async fn accounts_cannot_see_items_belonging_to_each_other(pool: PgPool) -> Resu
 
     Ok(())
 }
+
+#[sqlx::test]
+async fn can_render_login_page(pool: PgPool) -> Result<()> {
+    let router = build_router(pool)?;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/login")
+        .body(Body::empty())?;
+
+    let response = router.call(request).await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = read_full_body(response).await?;
+
+    assert!(body.contains("Login"));
+
+    Ok(())
+}


### PR DESCRIPTION
This is currently failing to render on the server since `&()` isn't valid JSON (and doesn't end up as an empty context). Let's add another method to be more explicit.

This change:
* Adds a `render_contextless` method
* Uses it in the login handler
* Adds a test to make sure it works
