### PR TITLE
fix: handle UTF-8 in items

### DIFF
--- a/templates/index.tera.html
+++ b/templates/index.tera.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="assets/style.css" />
     <script type="text/javascript" src="assets/script.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
At the moment, if you upload an item that contains "special" characters like `á` or emojis, it will get sent to the backend without proper encoding and persisted in the database. This means it will never show properly, but we just need to tell the browser that the content is all UTF-8 and it lines up nicely.

This change:
* Adds a `meta` tag to specify that it's all UTF-8
