### PR TITLE
feat: render code in Markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1388,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quanta"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
+dependencies = [
  "serde",
 ]
 
@@ -2165,7 +2202,9 @@ dependencies = [
  "dotenvy",
  "http-body-util",
  "moka",
+ "pulldown-cmark",
  "serde",
+ "serde_test",
  "sqlx",
  "sqlx-bootstrap",
  "tera",
@@ -2478,6 +2517,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ chrono = { version = "0.4.38", default-features = false, features = ["now"] }
 color-eyre = "0.6.3"
 dotenvy = "0.15.7"
 moka = { version = "0.12.8", features = ["future"] }
+pulldown-cmark = "0.12.2"
 serde = { version = "1.0.208", features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono"] }
 sqlx-bootstrap = { git = "https://github.com/alexander-jackson/sqlx-bootstrap.git", version = "0.1.0" }
@@ -22,4 +23,5 @@ uuid = { version = "1.10.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 http-body-util = "0.1.2"
+serde_test = "1.0.177"
 tower-util = "0.3.1"

--- a/assets/style.css
+++ b/assets/style.css
@@ -26,6 +26,11 @@ li {
   font-size: 30px;
 }
 
+code {
+  font-size: 30px;
+  color: #aab99a;
+}
+
 input[type="checkbox"] {
   width: 30px;
   height: 30px;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -84,13 +84,13 @@ mod tests {
     fn items_are_correctly_categorised() {
         let checked_item = Item {
             item_uid: Uuid::new_v4(),
-            content: "checked".to_owned(),
+            content: "checked".to_owned().into(),
             state: ItemState::Checked,
         };
 
         let unchecked_item = Item {
             item_uid: Uuid::new_v4(),
-            content: "unchecked".to_owned(),
+            content: "unchecked".to_owned().into(),
             state: ItemState::Unchecked,
         };
 
@@ -105,7 +105,7 @@ mod tests {
     fn deleted_items_are_ignored() {
         let deleted_item = Item {
             item_uid: Uuid::new_v4(),
-            content: "deleted".to_owned(),
+            content: "deleted".to_owned().into(),
             state: ItemState::Deleted,
         };
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,9 +4,11 @@ use axum::http::{Method, Request, StatusCode};
 use axum::response::Response;
 use axum::Router;
 use http_body_util::BodyExt;
+use serde_test::{assert_ser_tokens, Token};
 use sqlx::PgPool;
 use tower::Service;
 
+use crate::persistence::Content;
 use crate::router::IndexCache;
 use crate::templates::TemplateEngine;
 
@@ -83,4 +85,18 @@ async fn can_add_items(pool: PgPool) -> Result<()> {
     assert!(body.contains("Task"));
 
     Ok(())
+}
+
+#[test]
+fn item_content_without_any_markdown_should_be_transparently_rendered() {
+    let content = Content::from("very normal text".to_string());
+
+    assert_ser_tokens(&content, &[Token::Str("very normal text")]);
+}
+
+#[test]
+fn can_render_code_blocks_in_item_content() {
+    let content = Content::from("some `code` block".to_string());
+
+    assert_ser_tokens(&content, &[Token::Str("some <code>code</code> block")]);
 }

--- a/templates/index.tera.html
+++ b/templates/index.tera.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <link rel="stylesheet" href="assets/style.css" />
     <script type="text/javascript" src="assets/script.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -15,7 +15,7 @@
       {% for item in unchecked_items %}
       <li>
         <input type="checkbox" id="{{ item.item_uid }}" />
-        {{ item.content }}
+        {{ item.content | safe }}
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
You can currently write whatever you want in the content section but it doesn't really understand Markdown yet. I like writing in that syntax, so let's begin supporting it.

This change:
* Implements support for backticks as code blocks
